### PR TITLE
Fix: admin and vendor's purchase chart now has no upper limit

### DIFF
--- a/client/src/Components/Dashboards/AdminDashboard/AdminHome/MonthlyPurchaseChart/MonthlyPurchaseChart.jsx
+++ b/client/src/Components/Dashboards/AdminDashboard/AdminHome/MonthlyPurchaseChart/MonthlyPurchaseChart.jsx
@@ -78,7 +78,7 @@ const MonthlyPurchaseChart = ({ data }) => {
     scales: {
       y: {
         beginAtZero: true,
-        max: 90,
+        // max: 90,
       },
     },
   };

--- a/client/src/Components/Dashboards/VendorDashboard/VendorHome/VendorMonthlyPurchase/VendorMonthlyPurchase.jsx
+++ b/client/src/Components/Dashboards/VendorDashboard/VendorHome/VendorMonthlyPurchase/VendorMonthlyPurchase.jsx
@@ -1,15 +1,15 @@
-import React from "react";
-import { Bar } from "react-chartjs-2";
 import {
-  Chart as ChartJS,
-  CategoryScale,
-  LinearScale,
   BarElement,
+  CategoryScale,
+  Chart as ChartJS,
+  Legend,
+  LinearScale,
   Title,
   Tooltip,
-  Legend,
 } from "chart.js";
 import PropTypes from "prop-types";
+import React from "react";
+import { Bar } from "react-chartjs-2";
 
 ChartJS.register(
   CategoryScale,
@@ -96,7 +96,7 @@ const VendorMonthlyPurchase = ({ data }) => {
     scales: {
       y: {
         beginAtZero: true,
-        max: 100,
+        // max: 100,
       },
     },
   };


### PR DESCRIPTION
Fix: admin and vendor's purchase chart now has no upper limit